### PR TITLE
Line of code takes 12 seconds off runtime.

### DIFF
--- a/30timsort.js
+++ b/30timsort.js
@@ -121,7 +121,7 @@ var whenMerge = function (state) {
     var preRun = state.runStack[state.runStack.length - 2];
     if (state.runStack.length === 2) return preRun.length <= curRun.length;
     var pre2Run = state.runStack[state.runStack.length - 3];
-    if (curRun.length === preRun.length){return true;}
+    if (curRun.length >= preRun.length){return true;}
     return pre2Run.length <= preRun.length + curRun.length;
 };
 

--- a/30timsort.js
+++ b/30timsort.js
@@ -121,6 +121,7 @@ var whenMerge = function (state) {
     var preRun = state.runStack[state.runStack.length - 2];
     if (state.runStack.length === 2) return preRun.length <= curRun.length;
     var pre2Run = state.runStack[state.runStack.length - 3];
+    if (curRun.length === preRun.length){return true;}
     return pre2Run.length <= preRun.length + curRun.length;
 };
 


### PR DESCRIPTION
Apparently, this tim sort keeps merging uneven runs. Adding this code makes sure it prioritizes Even Runs. I ran this timsort(before edit) on 1000000 Integers in a random order. It took a whopping 12 SECONDS vs. The normal merge sort's 2 seconds.  Now, it's run time is improved to 0.9 seconds.
